### PR TITLE
Version 0.4.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "Mustard Simplify",
     "description": "A set of tools to simplify scenes for better viewport performance",
     "author": "Mustard",
-    "version": (0, 4, 0, 5),
+    "version": (0, 4, 1, 2),
     "blender": (4, 1, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardSimplify/wiki",

--- a/menu/menu_simplify.py
+++ b/menu/menu_simplify.py
@@ -50,13 +50,21 @@ class MUSTARDSIMPLIFY_PT_Simplify(MainPanel, bpy.types.Panel):
             col = box.column(align=True)
             col.enabled = not settings.simplify_status
             row = col.row()
+            row.prop(settings, "objects")
+            row.operator("mustard_simplify.menu_objects_select", icon="PREFERENCES", text="")
+
+            row = col.row()
             row.prop(settings, "modifiers")
             row.operator("mustard_simplify.menu_modifiers_select", icon="PREFERENCES", text="")
+
             row = col.row()
             row.prop(settings, "shape_keys")
             row.operator("mustard_simplify.menu_shape_keys_settings", icon="PREFERENCES", text="")
+
             col.prop(settings, "drivers")
+
             col.prop(settings, "physics")
+
             col.prop(settings, "normals_auto_smooth")
 
         box = layout.box()
@@ -98,6 +106,9 @@ class MUSTARDSIMPLIFY_PT_Simplify(MainPanel, bpy.types.Panel):
 
                         col = box.column(align=True)
                         col.label(text="Properties to Simplify", icon="PROPERTIES")
+
+                        row = col.row()
+                        row.prop(obj, 'visibility')
 
                         row = col.row()
                         row.enabled = obj.exception.type == "MESH" or obj.exception.type == "GPENCIL"

--- a/menu/menu_simplify.py
+++ b/menu/menu_simplify.py
@@ -102,7 +102,7 @@ class MUSTARDSIMPLIFY_PT_Simplify(MainPanel, bpy.types.Panel):
                         item_in_exception_collection = False
                         if settings.exception_collection is not None:
                             item_in_exception_collection = obj.exception in [x for x in (settings.exception_collection.all_objects if settings.exception_include_subcollections else settings.exception_collection.objects)]
-                        box.enabled = not item_in_exception_collection
+                        box.enabled = not item_in_exception_collection and not settings.simplify_status
 
                         col = box.column(align=True)
                         col.label(text="Properties to Simplify", icon="PROPERTIES")

--- a/settings/settings_addon.py
+++ b/settings/settings_addon.py
@@ -27,6 +27,9 @@ class MustardSimplify_AddonPrefs(bpy.types.AddonPreferences):
         col.prop(self, "debug")
 
         col = layout.column(align=True)
+        col.operator("mustard_simplify.reset_settings", icon="GHOST_DISABLED")
+
+        col = layout.column(align=True)
         col.operator("mustard_simplify.openlink", text="Check Version",
                         icon="URL").url = "https://github.com/Mustard2/MustardSimplify/releases"
         col.operator("mustard_simplify.openlink", text="Report Issue",

--- a/settings/settings_main.py
+++ b/settings/settings_main.py
@@ -40,6 +40,11 @@ class MustardSimplify_Settings(bpy.types.PropertyGroup):
                                       description="Disable Normals Auto Smooth",
                                       default=True)
 
+    # Objects
+    objects: BoolProperty(name="Objects",
+                          description="Hide objects",
+                          default=False)
+
     # UI Settings
     collapse_options: BoolProperty(name="Collapse",
                                    default=True)
@@ -80,6 +85,9 @@ class MustardSimplify_Settings(bpy.types.PropertyGroup):
 
     # Modifiers to not simplify by default
     modifiers_ignore = ["ARMATURE", "HOOK"]
+
+    # Objects to not simplify by default
+    objects_ignore = ["MESH", "LIGHT", "CAMERA", "EMPTY", "ARMATURE", "CURVE", "SURFACE", "FONT"]
 
 
 def register():

--- a/simplify/__init__.py
+++ b/simplify/__init__.py
@@ -2,6 +2,7 @@ from . import ui_exceptions
 from . import simplify_status
 from . import ops_settings_blender_simplify
 from . import ops_settings_modifiers
+from . import ops_settings_objects
 from . import ops_settings_shape_keys
 from . import ops_simplify
 
@@ -10,6 +11,7 @@ def register():
     simplify_status.register()
     ops_settings_shape_keys.register()
     ops_settings_modifiers.register()
+    ops_settings_objects.register()
     ops_settings_blender_simplify.register()
     ui_exceptions.register()
     ops_simplify.register()
@@ -19,6 +21,7 @@ def unregister():
     ops_simplify.unregister()
     ui_exceptions.unregister()
     ops_settings_blender_simplify.unregister()
+    ops_settings_objects.unregister()
     ops_settings_modifiers.unregister()
     ops_settings_shape_keys.unregister()
     simplify_status.unregister()

--- a/simplify/ops_settings_modifiers.py
+++ b/simplify/ops_settings_modifiers.py
@@ -2,7 +2,6 @@ import bpy
 from bpy.props import *
 
 
-# Classes to manage exceptions
 class MustardSimplify_SetModifier(bpy.types.PropertyGroup):
     name: StringProperty(default="")
     disp_name: StringProperty(default="")
@@ -189,7 +188,7 @@ class MUSTARDSIMPLIFY_OT_MenuModifiersSelect(bpy.types.Operator):
             try:
                 row2.label(text=m.disp_name, icon=m.icon)
             except:
-                row2.label(text=m.name, icon="BLANK1")
+                row2.label(text=m.disp_name, icon="BLANK1")
 
         box = layout.box()
 

--- a/simplify/ops_settings_objects.py
+++ b/simplify/ops_settings_objects.py
@@ -1,0 +1,125 @@
+import bpy
+from bpy.props import *
+
+
+class MustardSimplify_SetObject(bpy.types.PropertyGroup):
+    name: StringProperty(default="")
+    disp_name: StringProperty(default="")
+    icon: StringProperty(default="")
+    simplify: BoolProperty(default=True)
+
+
+class MustardSimplify_SetObjects(bpy.types.PropertyGroup):
+    objects: CollectionProperty(type=MustardSimplify_SetObject)
+
+
+class MUSTARDSIMPLIFY_OT_MenuObjectSelect(bpy.types.Operator):
+    """Select the Objects affected by the simplification process"""
+    bl_idname = "mustard_simplify.menu_objects_select"
+    bl_label = "Select Objects to Simplify"
+
+    @classmethod
+    def poll(cls, context):
+        # Enable operator only when the scene is not simplified
+        settings = bpy.context.scene.MustardSimplify_Settings
+        return not settings.simplify_status
+
+    def execute(self, context):
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+
+        def add_object(collection, name, disp_name, icon, simplify):
+            for el in collection:
+                if el.name == name:
+                    return False
+            add_item = collection.add()
+            add_item.name = name
+            add_item.disp_name = disp_name
+            add_item.icon = icon
+            add_item.simplify = simplify
+            return True
+
+        scene = bpy.context.scene
+        settings = scene.MustardSimplify_Settings
+        objects = scene.MustardSimplify_SetObjects.objects
+        addon_prefs = context.preferences.addons["MustardSimplify"].preferences
+
+        # Extract type of Objects
+        rna = bpy.ops.object.add.get_rna_type()
+        objs_list = rna.bl_rna.properties['type'].enum_items.keys()
+
+        # Make the list
+        # This is done at run-time, so it should be version agnostic
+        if len(objs_list) != len(objects):
+
+            objects.clear()
+
+            for m in objs_list:
+
+                # Change the displayed name
+                disp_name = m.replace("_", " ")
+                disp_name = disp_name.title()
+
+                icon = m + "_DATA"
+                simplify = True
+
+                # Manage single exceptions
+                if m in ["LIGHT_PROBE"]:
+                    icon = "OUTLINER_DATA_LIGHTPROBE"
+                elif m in ["SPEAKER"]:
+                    icon = "OUTLINER_DATA_SPEAKER"
+                elif m in ["GPENCIL", "GREASEPENCIL"]:
+                    disp_name = "Grease Pencil"
+                    if m == "GPENCIL":
+                        disp_name += " (old)"
+                    icon = "OUTLINER_DATA_GREASEPENCIL"
+
+                if m in settings.objects_ignore:
+                    simplify = False
+
+                add_object(objects, m, disp_name, icon, simplify)
+
+            if addon_prefs.debug:
+                print("Mustard Simplify - Objects List generated for Objects")
+
+        return context.window_manager.invoke_props_dialog(self, width=780)
+
+    def draw(self, context):
+
+        scene = bpy.context.scene
+        objects = scene.MustardSimplify_SetObjects.objects
+
+        layout = self.layout
+        box = layout.box()
+
+        box.label(text="Objects")
+
+        row = box.row()
+        col = row.column()
+
+        for i, m in enumerate(objects, 0):
+            if m.name == "GREASEPENCIL":
+                col = row.column()
+            row2 = col.row()
+            row2.prop(m, 'simplify', text="")
+            # Avoid missing icon error
+            try:
+                row2.label(text=m.disp_name, icon=m.icon)
+            except:
+                row2.label(text=m.disp_name, icon="BLANK1")
+
+
+def register():
+    bpy.utils.register_class(MustardSimplify_SetObject)
+
+    bpy.utils.register_class(MustardSimplify_SetObjects)
+    bpy.types.Scene.MustardSimplify_SetObjects = PointerProperty(type=MustardSimplify_SetObjects)
+
+    bpy.utils.register_class(MUSTARDSIMPLIFY_OT_MenuObjectSelect)
+
+
+def unregister():
+    bpy.utils.unregister_class(MUSTARDSIMPLIFY_OT_MenuObjectSelect)
+    bpy.utils.unregister_class(MustardSimplify_SetObjects)
+    bpy.utils.unregister_class(MustardSimplify_SetObject)

--- a/simplify/simplify_status.py
+++ b/simplify/simplify_status.py
@@ -15,7 +15,10 @@ class MustardSimplify_ShapeKeysStatus(bpy.types.PropertyGroup):
 
 # Class with all the settings variables
 class MustardSimplify_ObjectStatus(bpy.types.PropertyGroup):
-    # Normals Auto Smooth
+    # Object visibility status
+    visibility: bpy.props.BoolProperty(default=True)
+
+    # Normals Auto Smooth status
     normals_auto_smooth: bpy.props.BoolProperty(default=True)
     # Modifiers status
     modifiers: bpy.props.CollectionProperty(type=MustardSimplify_ModifierStatus)
@@ -43,6 +46,9 @@ class MustardSimplify_Exception(bpy.types.PropertyGroup):
     normals_auto_smooth: bpy.props.BoolProperty(name="Normals Auto Smooth",
                                                 description="Disable Normals Auto Smooth",
                                                 default=False)
+    visibility: bpy.props.BoolProperty(name="Visibility",
+                                       description="Hide the Object",
+                                       default=False)
 
 
 class MustardSimplify_Exceptions(bpy.types.PropertyGroup):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,9 +1,12 @@
 from . import ops_link
+from . import ops_reset
 
 
 def register():
     ops_link.register()
+    ops_reset.register()
 
 
 def unregister():
+    ops_reset.unregister()
     ops_link.unregister()

--- a/utils/ops_reset.py
+++ b/utils/ops_reset.py
@@ -1,0 +1,27 @@
+import bpy
+from bpy.props import *
+
+
+class MUSTARDSIMPLIFY_OT_ResetSettings(bpy.types.Operator):
+    """Reset addon settings"""
+    bl_idname = "mustard_simplify.reset_settings"
+    bl_label = "Reset Settings"
+    bl_options = {'REGISTER'}
+
+    def execute(self, context):
+
+        scene = bpy.context.scene
+        modifiers = scene.MustardSimplify_SetModifiers.modifiers
+        objects = scene.MustardSimplify_SetObjects.objects
+
+        modifiers.clear()
+        objects.clear()
+        return {'FINISHED'}
+
+
+def register():
+    bpy.utils.register_class(MUSTARDSIMPLIFY_OT_ResetSettings)
+
+
+def unregister():
+    bpy.utils.unregister_class(MUSTARDSIMPLIFY_OT_ResetSettings)


### PR DESCRIPTION
- **Feature**: Possibility to disable some types of Objects, or add their visibility to the exception list
- **Feature**: Added a button to reset the add-on settings to default
- **Bug**: fixed a bug that was allowing a change of settings when Simplify was active, leading to undefined behaviour
- **Bug**: fixed a bug that was preventing the Normals Auto Smooth option in Blender < 4.1 to work
- **Bug**: fixed a bug that might lead to an incorrect visualization of modifier names in the simplify list