### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   lint:
     name: Formatting and Linting


### PR DESCRIPTION
Potential fix for [https://github.com/Mustard2/MustardSimplify/security/code-scanning/2](https://github.com/Mustard2/MustardSimplify/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/workflows.yml` so all jobs inherit least-privilege defaults unless overridden.  
Best single fix without changing functionality: set minimal read-only permissions for common CI behavior:

- `contents: read` (needed by checkout and source access)
- `packages: read` (safe baseline for package reads/caches)

Place this block right after the workflow trigger section (`on:` ...) and before `jobs:` so it applies globally to both `lint` and `blender`.

No imports, methods, or definitions are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
